### PR TITLE
Update redpanda image from 23.1.7 to 24.1.2

### DIFF
--- a/03-basic-streaming/docker-compose.yml
+++ b/03-basic-streaming/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
  redpanda:
-   image: docker.redpanda.com/redpandadata/redpanda:v23.1.7
+   image: docker.redpanda.com/redpandadata/redpanda:v24.1.2
    container_name: redpanda-1
    command:
    - redpanda


### PR DESCRIPTION
Hi :wave: 

Docker image is one year old ([v23.1.7](https://github.com/redpanda-data/redpanda/releases/tag/v23.1.7))
It seems ok to go through the course with v24.

Also I'm having a bit of trouble in RP-102 if i try to use v24, but i don't know if it's because i'm a beginner or if there is some changes to be made in the content :sweat_smile: 